### PR TITLE
fix tokio runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ spdx = "0.10.0"
 which = "4.4.0"
 axum = "0.6.18"
 rust-embed = "6.6.1"
-tokio = "1.28.1"
+tokio = { version = "1.28.1", features = ["rt-multi-thread"] } 
 mime_guess = "2.0.4"
 filetime = "0.2.21"
 rayon = "1.7.0"

--- a/hab-auto-build.json
+++ b/hab-auto-build.json
@@ -1,15 +1,15 @@
 {
     "repos": [{
         "id": "core",
-        "source": "../bootstrap-plans",
+        "source": "../core-packages",
         "native_packages": [
+            "packages/bootstrap/build-support/**",
             "packages/bootstrap/build-tools/cross-compiler/**",
             "packages/bootstrap/build-tools/host-tools/**",
             "packages/bootstrap/build-tools/cross-tools/**"
         ],
         "ignored_packages": [
             "draft/**"
-
         ]
     }]
 }


### PR DESCRIPTION
fixes the following issue:

:Runtime::new()?;
    |                                       ^^^ function or associated item not found in `Runtime`